### PR TITLE
Updated Memtest86+ and fixed path in pxelinux.cfg

### DIFF
--- a/pxenow
+++ b/pxenow
@@ -629,7 +629,7 @@ def main(mounted_files) -> int:
 
 	generate_dnsmasq_configuration(interface, server)
 
-	get_img_file("Memtest86+", "memtest", "http://www.memtest.org/download/5.01/memtest86+-5.01.zip", "memtest86+-5.01.bin")
+	get_img_file("Memtest86+", "memtest", "https://www.memtest.org/download/v7.00/mt86plus_7.00.binaries.zip", "memtest32.bin")
 	get_img_file("PLoP", "plpbt.bin", "https://download.plop.at/files/bootmngr/plpbt-5.0.15.zip", "plpbt-5.0.15/plpbt.bin")
 	get_img_file("netboot.xyz", "netbootxyz", "https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn", "")
 

--- a/tftp/boot/pxelinux.cfg/default
+++ b/tftp/boot/pxelinux.cfg/default
@@ -31,8 +31,8 @@ MENU COLOR timeout      1;30;47
 MENU COLOR tabmsg       1;30;47
 
 LABEL memtest
-	MENU LABEL Memtest86+ v5.01
-	KERNEL img/memtest
+	MENU LABEL Memtest86+ v7.00
+	KERNEL img/included/memtest
 
 LABEL hdt
 	MENU LABEL HDT (Hardware Detection Tool)


### PR DESCRIPTION
The provided link to Memtest86+ was dead so I replaced it with the latest version.
Also pxelinux is now configured to look for it in the same path where it's saved `img/included` instead of `img`.